### PR TITLE
ByteUtils using arrays over seqs and lists

### DIFF
--- a/Combinator/ByteUtils.fs
+++ b/Combinator/ByteUtils.fs
@@ -22,22 +22,23 @@ module ByteUtils =
                         | One -> byte(1)
                         | Zero -> byte(0)
 
-    let bitMasks = Seq.unfold (fun bitIndex -> Some((byte(pown 2 bitIndex), bitIndex), bitIndex + 1)) 0                           
-                            |> Seq.take 8
-                            |> Seq.toList
-                            |> List.rev
+    let bitMasks = 
+        let maskArr:(byte*int)[] = Array.zeroCreate 8
+        maskArr 
+            |> Array.iteri 
+                ( fun i elm -> maskArr.[i] <- (byte(pown 2 i), i))   
+        maskArr 
+            |> Array.rev
 
     let byteToBitArray b = 
-            List.map (fun (bitMask, bitPosition) -> 
-                        if (b &&& bitMask) >>> bitPosition = byte(0) then Zero
+        Array.map 
+            ( fun (bitMask, bitPosition) -> 
+                        if   (b &&& bitMask) >>> bitPosition = byte(0) 
+                        then Zero
                         else One) bitMasks
 
     let bytesToBits (bytes:byte[]) =        
-        bytes 
-            |> Array.toList
-            |> List.map byteToBitArray
-            |> List.collect id
-            |> List.toArray
+        bytes |> Array.collect byteToBitArray
 
     let bitsToUInt (bits:Bit[])  = 
         let positions = Array.zip bits (Array.rev [|0..Array.length bits - 1|])


### PR DESCRIPTION
Switched the bitMasks val, along with the  byteToBitArray and
bytesToBits functions to only use arrays over converting from arrays to
lists or sequences and then back to arrays
