### PR TITLE
F# BlitParser Implementation

### DIFF
--- a/Combinator/BinParser.fs
+++ b/Combinator/BinParser.fs
@@ -112,7 +112,7 @@ module BinParsers =
         member x.bit7 = x.bitN 7
         member x.bit8 = x.bitN 8     
     
-    let parseStruct<'T, 'UserState> networkOrder numEntries (bp:BinParser<'UserState>) : Parser<_,_,_,'UserState> = 
+    let parseStruct<'T , 'UserState when 'T: unmanaged > networkOrder numEntries (bp:BinParser<'UserState>) : Parser<_,_,_,'UserState> = 
             let size = sizeofType typeof<'T>
             let requiredBytes = size * numEntries
 
@@ -122,7 +122,7 @@ module BinParsers =
                      
             preturn <| byteArrayToObjects<'T> (converter bytes) networkOrder
 
-    let defineStructParserLE<'T> = parseStruct<'T, unit> false
+    let defineStructParserLE<'T when 'T: unmanaged > = parseStruct<'T, unit> false
 
-    let defineStructParserBE<'T> = parseStruct<'T, unit> true
+    let defineStructParserBE<'T when 'T: unmanaged > = parseStruct<'T, unit> true
 

--- a/Samples/Mp4Matcher/Mp4DataTypes.fs
+++ b/Samples/Mp4Matcher/Mp4DataTypes.fs
@@ -30,7 +30,7 @@ module Mp4DataTypes =
     /// </summary>
     let bp = new BinParser<_>(Array.rev)
 
-    let pStructs<'T> entries : VideoParser<_> = parseStruct<'T, VideoState> true entries bp
+    let pStructs<'T when 'T: unmanaged> entries : VideoParser<_> = parseStruct<'T, VideoState> true entries bp
 
     let mp4Stream f = new BinStream<VideoState>(f, { IsAudio = false; CurrentStatePosition = (int64)0}, BinStreams.createCache())
 


### PR DESCRIPTION
Since there's no F# equivalent to a void\* I declared the local variable for the pointer to the result[] as an IntPtr so there'd be no need for the Explicit conversion from void\* to IntPtr later.

Added the " 'T  when  'T: unmanaged " constraint to functions that use the unsafe BlitParser
