### PR TITLE
Fix takeTillWithCount fn Bug

### DIFF
--- a/Combinator/Combinator.fs
+++ b/Combinator/Combinator.fs
@@ -120,7 +120,7 @@ module Combinator =
                     | x when x < minCount -> failwith ("Needed to consume at least " + minCount.ToString() + " element but did not")
                     | _ -> (None, currentState)
                
-        fun (state: State<_,_,_>) ->
+        fun state ->
             let rec many' parser (resultList, currentState:State<_,_,_>) =
                 let mutable lastPosition = currentState.position ()
                 let returnValue() = didFind resultList currentState
@@ -128,13 +128,10 @@ module Combinator =
                 | false -> returnValue()
                 | true ->
                     match parser currentState with
-                        | Some(result), (nextState : State<_,_,_>) when lastPosition = nextState.position ()
-                            -> didFind (result::resultList) currentState
-                        | Some(result), nextState when not <| predicate (result::resultList)  ->
-                            lastPosition <- nextState.position ()
-                            many' parser (result::resultList, nextState)
-                        | Some(_), _ ->
-                            currentState.backtrack(); returnValue()
+                        | Some(_), (nextState : State<_,_,_>) when lastPosition = nextState.position () -> returnValue()
+                        | Some(result), nextState when not <| predicate (result::resultList)  -> lastPosition <- nextState.position ()
+                                                                                                 many' parser (result::resultList, nextState)
+                        | Some(_), _ -> currentState.backtrack(); returnValue()
                         | _ -> returnValue()
                         
                                   

--- a/Combinator/Combinator.fs
+++ b/Combinator/Combinator.fs
@@ -116,7 +116,7 @@ module Combinator =
 
         let didFind found currentState = 
                 match List.length found with 
-                    | x when x > 0 && x >= minCount -> (Some(List.rev found), currentState) 
+                    | x when x >= minCount -> (Some(List.rev found), currentState)
                     | x when x < minCount -> failwith ("Needed to consume at least " + minCount.ToString() + " element but did not")
                     | _ -> (None, currentState)
                

--- a/Combinator/Combinator.fs
+++ b/Combinator/Combinator.fs
@@ -120,17 +120,22 @@ module Combinator =
                     | x when x < minCount -> failwith ("Needed to consume at least " + minCount.ToString() + " element but did not")
                     | _ -> (None, currentState)
                
-        fun state ->
-            let rec many' parser (resultList, currentState:State<_,_,_>) =              
+        fun (state: State<_,_,_>) ->
+            let rec many' parser (resultList, currentState:State<_,_,_>) =
+                let mutable lastPosition = currentState.position ()
                 let returnValue() = didFind resultList currentState
-
                 match currentState.hasMore() with
-                    | false -> returnValue()
-                    | true ->                        
-                        match parser currentState with
-                            | Some(result), nextState when not <| predicate (result::resultList)  -> many' parser (result::resultList, nextState)
-                            | Some(_), _ ->  currentState.backtrack(); returnValue()
-                            | _ ->  returnValue()
+                | false -> returnValue()
+                | true ->
+                    match parser currentState with
+                        | Some(result), (nextState : State<_,_,_>) when lastPosition = nextState.position ()
+                            -> didFind (result::resultList) currentState
+                        | Some(result), nextState when not <| predicate (result::resultList)  ->
+                            lastPosition <- nextState.position ()
+                            many' parser (result::resultList, nextState)
+                        | Some(_), _ ->
+                            currentState.backtrack(); returnValue()
+                        | _ -> returnValue()
                         
                                   
             many' parser ([], state)

--- a/Combinator/StringP.fs
+++ b/Combinator/StringP.fs
@@ -9,7 +9,7 @@ module StringP =
     
     type ParseState<'UserState> = IStreamP<string,string,'UserState>
 
-    let foldStrings = fun (strings : string list) -> preturn (List.reduce (+) strings)
+    let foldStrings strings = preturn (String.concat "" strings)
 
     let isMatch regex item = Regex.IsMatch(item, regex)
 
@@ -70,7 +70,7 @@ module StringP =
 
     let ws s = (opt (many (satisfy isSpace any))
                     >>= function
-                        | Some(i) -> preturn (List.reduce (+) i)
+                        | Some(i) -> preturn (String.concat "" i)
                         | None -> preturn "") s
 
     let isNewLine i = isMatch "\r\n" i || isMatch "\r" i || isMatch "\n" i

--- a/Combinator/StringStream.fs
+++ b/Combinator/StringStream.fs
@@ -59,7 +59,7 @@ module StringStreamP =
 
             member x.setUserState s = userState <- s
 
-            member x.position () = (int64)0   
+            member x.position () = int64 state.Length
 
         member x.startsWith (inputStream:IStreamP<string, string, 'UserState>) target = 
             if String.IsNullOrEmpty inputStream.state then None

--- a/Samples/FsTests/BinaryUnitTests.fs
+++ b/Samples/FsTests/BinaryUnitTests.fs
@@ -358,7 +358,7 @@ let lookaheadAndSeekRaw () =
 
 
 [<Test>]
-let testMany () =
+let testManyZeroOrMoreMatches () =
   let (bp: BinParser<unit>) = new BinParser<_> (id)
 
   let pByteZero = bp.matchBytes [| 00uy |] |>> (fun _ -> 00uy)

--- a/Samples/FsTests/BinaryUnitTests.fs
+++ b/Samples/FsTests/BinaryUnitTests.fs
@@ -354,4 +354,27 @@ let lookaheadAndSeekRaw () =
 
     fs.Dispose()
 
-    File.Delete testFile 
+    File.Delete testFile
+
+
+[<Test>]
+let testMany () =
+  let (bp: BinParser<unit>) = new BinParser<_> (id)
+
+  let pByteZero = bp.matchBytes [| 00uy |] |>> (fun _ -> 00uy)
+
+  let pByteOne = bp.matchBytes [| 01uy |] |>> (fun _ -> 01uy)
+
+  let parser = parse {
+    let! zeros = many pByteZero
+    let! ones = many pByteOne
+    return zeros, ones
+  }
+
+  let bytes = [| 01uy; 02uy |]
+
+  let s = new MemoryStream (bytes) |> makeBinStream
+
+  let result = test s parser
+
+  result |> should equal (([]: byte list), [1uy])

--- a/Samples/FsTests/CsvSampleTests.fs
+++ b/Samples/FsTests/CsvSampleTests.fs
@@ -119,7 +119,7 @@ let testEmpties() =
 
     let result = test csv lines
 
-    result |> should equal [[None;None;None;None]]
+    result |> should equal [[Some "";Some "";Some "";Some ""]]
 
 [<Test>]
 let testCsvWithQuotes2() = 
@@ -131,7 +131,7 @@ a,b,\\\", \"cd,fg\",,"
     let result = test csv lines |> List.toArray
 
     result.[0] |> should equal (["a";"b 1.\\";"cd,fg"] |> List.map Some)
-    result.[1] |> should equal ([Some("a");Some("b");Some("\"");Some("cd,fg");None;None])
+    result.[1] |> should equal ([Some("a");Some("b");Some("\"");Some("cd,fg");Some "";Some ""])
 
 [<Test>]
 let testCsvWithOptionalElements() = 
@@ -141,7 +141,7 @@ let testCsvWithOptionalElements() =
 
     let result = test csv lines |> List.toArray
 
-    result.[0] |> should equal ([None; None; None])    
+    result.[0] |> should equal ([Some ""; Some ""; Some ""])
 
 
 
@@ -200,7 +200,7 @@ faisal rules!"
 
     let result = test csv lines |> List.toArray
 
-    result.[0] |> should equal ([Some("foo,"); None; Some("bar"); Some("baz\"")])  
+    result.[0] |> should equal ([Some("foo,"); Some ""; Some("bar"); Some("baz\"")])
 
 [<Test>]
 let testDoubleQuotes () = 
@@ -210,7 +210,7 @@ let testDoubleQuotes () =
 
     let result = test csv lines |> List.toArray
 
-    result |> should equal [[Some(@"a b def foo"); None]]
+    result |> should equal [[Some(@"a b def foo"); Some ""]]
 
 [<Test>]
 [<ExpectedException>]

--- a/Samples/FsTests/FsTests.fsproj
+++ b/Samples/FsTests/FsTests.fsproj
@@ -74,7 +74,6 @@
     <None Include="sample_mpeg4.mp4">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
-    <Compile Include="ManyUnitTest.fs" />
   </ItemGroup>
   <PropertyGroup>
     <MinimumVisualStudioVersion Condition="'$(MinimumVisualStudioVersion)' == ''">11</MinimumVisualStudioVersion>

--- a/Samples/FsTests/FsTests.fsproj
+++ b/Samples/FsTests/FsTests.fsproj
@@ -74,6 +74,7 @@
     <None Include="sample_mpeg4.mp4">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
+    <Compile Include="ManyUnitTest.fs" />
   </ItemGroup>
   <PropertyGroup>
     <MinimumVisualStudioVersion Condition="'$(MinimumVisualStudioVersion)' == ''">11</MinimumVisualStudioVersion>

--- a/Samples/FsTests/ManyUnitTest.fs
+++ b/Samples/FsTests/ManyUnitTest.fs
@@ -1,0 +1,25 @@
+module ManyUnitTests
+
+open NUnit.Framework
+open FsUnit
+open System.IO
+open ParsecClone.BinaryCombinator
+open ParsecClone.CombinatorBase
+
+let (bp: BinParser<unit>) = new BinParser<_> (id)
+
+let pByteZero = bp.matchBytes [| 00uy |] |>> (fun _ -> 00uy)
+let pByteOne = bp.matchBytes [| 01uy |] |>> (fun _ -> 01uy)
+
+let parser = parse {
+  let! zeros = many pByteZero
+  let! ones = many pByteOne
+  return zeros, ones
+}
+
+[<Test>]
+let testMany () = 
+  let bytes = [| 01uy; 02uy |]
+  let s = new MemoryStream (bytes) |> makeBinStream
+  let result = test s parser
+  result |> should equal (([]: byte list), [1uy])


### PR DESCRIPTION
Hi,
Currently, the `many` function does not allow zero match. This is because the
internal function `takeTillWithCount` checks the number of results accumulated
in the current state, and returns `None` if the result is empty. However, this
prevents the `many` function to have zero or more matches. For example, in the
following code snippet, I would expect to have a match, but the code raises an
exception. This PR tries to fix this bug by removing the unnecessary condition
in the match statement. Because of the `minCount` variable, I believe this fix
does not affect the correctness of other functions that are dependent on it.
```fsharp
#r "packages/ParsecClone/lib/net45/ParsecClone.Combinator.dll"
open ParsecClone.BinaryCombinator
open ParsecClone.CombinatorBase
let (bp: BinParser<unit>) = new BinParser<_> (id)
let pByteZero = bp.matchBytes [| 00uy |] |>> (fun _ -> 00uy)
let pByteOne = bp.matchBytes [| 01uy |] |>> (fun _ -> 01uy)
let parser = parse {
  let! zeros = many pByteZero
  let! ones = many pByteOne
  return zeros, ones
}
let _ =
  let bytes = [| 01uy; 01uy |]
  let s = new System.IO.MemoryStream (bytes) |> makeBinStream
  test s parser (*should not raise exception here*)
```
